### PR TITLE
Changed to be able to build the sample module as an application

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,7 +17,7 @@
 import com.google.android.material.composethemeadapter.Libs
 
 plugins {
-    id 'com.android.library'
+    id 'com.android.application'
     id 'kotlin-android'
 }
 


### PR DESCRIPTION
## Overview
I wanted to build a sample project so I made this PR.
If there is a reason why you have to make the sample module as library, there is no problem closing this PR.