### PR TITLE
Bump version to 1.0.0-alpha02

### DIFF
--- a/buildSrc/src/main/java/com/google/android/material/composethemeadapter/dependencies.kt
+++ b/buildSrc/src/main/java/com/google/android/material/composethemeadapter/dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha08"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha09"
 
     const val gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.12.0"
 
@@ -47,7 +47,7 @@ object Libs {
             val snapshotUrl: String
                 get() = "https://androidx.dev/snapshots/builds/$snapshot/artifacts/ui/repository/"
 
-            private const val version = "1.0.0-alpha01"
+            private const val version = "1.0.0-alpha02"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val foundation = "androidx.compose.foundation:foundation:${version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.parallel=true
 ##########################
 
 GROUP=com.google.android.material
-VERSION_NAME=1.0.0-SNAPSHOT
+VERSION_NAME=1.0.0-alpha02
 
 POM_DESCRIPTION=A library that enables reuse of Material Components for Android themes for theming in Jetpack Compose
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -18,4 +18,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -1,5 +1,5 @@
 public final class com/google/android/material/composethemeadapter/MdcTheme {
-	public static final fun MdcTheme (Landroid/content/Context;ZZZZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun MdcTheme (Landroid/content/Context;ZZZZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun createMdcTheme (Landroid/content/Context;Landroidx/compose/ui/unit/Density;ZZZZ)Lcom/google/android/material/composethemeadapter/ThemeParameters;
 	public static synthetic fun createMdcTheme$default (Landroid/content/Context;Landroidx/compose/ui/unit/Density;ZZZZILjava/lang/Object;)Lcom/google/android/material/composethemeadapter/ThemeParameters;
 }


### PR DESCRIPTION
Compose 1.0.0-alpha02 [introduced](https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.0.0-alpha02) binary breaking change. Library must be recompiled to work with this version of the compose compiler plugin.