### PR TITLE
Update deploy_docs CI to JDK 11

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup JDK 8 (1.8)
+      - name: Setup JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Fixing docs deploy:
https://github.com/material-components/material-components-android-compose-theme-adapter/runs/1791951084?check_suite_focus=true