### PR TITLE
Set LocalContentColor

### DIFF
--- a/lib/src/androidTest/java/com/google/android/material/composethemeadapter/MdcThemeTest.kt
+++ b/lib/src/androidTest/java/com/google/android/material/composethemeadapter/MdcThemeTest.kt
@@ -20,6 +20,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalContext
@@ -88,6 +89,9 @@ class MdcThemeTest<T : AppCompatActivity>(activityClass: Class<T>) {
 
             assertEquals(colorResource(R.color.light_coral), color.background)
             assertEquals(colorResource(R.color.orchid), color.onBackground)
+
+            // MdcTheme updates the LocalContentColor to match the calculated onBackground
+            assertEquals(colorResource(R.color.orchid), LocalContentColor.current)
         }
     }
 

--- a/lib/src/main/java/com/google/android/material/composethemeadapter/MdcTheme.kt
+++ b/lib/src/main/java/com/google/android/material/composethemeadapter/MdcTheme.kt
@@ -21,12 +21,14 @@ import android.content.Context
 import android.content.res.Resources
 import android.view.View
 import androidx.compose.material.Colors
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Shapes
 import androidx.compose.material.Typography
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -96,8 +98,14 @@ fun MdcTheme(
         colors = themeParams.colors ?: MaterialTheme.colors,
         typography = themeParams.typography ?: MaterialTheme.typography,
         shapes = themeParams.shapes ?: MaterialTheme.shapes,
-        content = content
-    )
+    ) {
+        // We update the LocalContentColor to match our onBackground. This allows the default
+        // content color to be more appropriate to the theme background
+        CompositionLocalProvider(
+            LocalContentColor provides MaterialTheme.colors.onBackground,
+            content = content
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
We update the `LocalContentColor` to match our `onBackground`. This allows the default content color to be more appropriate to the theme background.

See https://github.com/chrisbanes/accompanist/pull/223

Fixes #49 