### PR TITLE
Add setDefaultFontFamily functionality

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -13,9 +13,9 @@ public final class com/google/android/material/composethemeadapter/FontFamilyWit
 }
 
 public final class com/google/android/material/composethemeadapter/MdcTheme {
-	public static final fun MdcTheme (Landroid/content/Context;ZZZZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun createMdcTheme (Landroid/content/Context;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/Density;ZZZZ)Lcom/google/android/material/composethemeadapter/ThemeParameters;
-	public static synthetic fun createMdcTheme$default (Landroid/content/Context;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/Density;ZZZZILjava/lang/Object;)Lcom/google/android/material/composethemeadapter/ThemeParameters;
+	public static final fun MdcTheme (Landroid/content/Context;ZZZZZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun createMdcTheme (Landroid/content/Context;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/Density;ZZZZZ)Lcom/google/android/material/composethemeadapter/ThemeParameters;
+	public static synthetic fun createMdcTheme$default (Landroid/content/Context;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/Density;ZZZZZILjava/lang/Object;)Lcom/google/android/material/composethemeadapter/ThemeParameters;
 }
 
 public final class com/google/android/material/composethemeadapter/ThemeParameters {
@@ -43,7 +43,7 @@ public final class com/google/android/material/composethemeadapter/TypedArrayUti
 	public static synthetic fun getTextUnit-lGoEivg$default (Landroid/content/res/TypedArray;ILandroidx/compose/ui/unit/Density;JILjava/lang/Object;)J
 	public static final fun getTextUnitOrNull (Landroid/content/res/TypedArray;ILandroidx/compose/ui/unit/Density;)Landroidx/compose/ui/unit/TextUnit;
 	public static final fun parseShapeAppearance (Landroid/content/Context;ILandroidx/compose/foundation/shape/CornerBasedShape;Landroidx/compose/ui/unit/LayoutDirection;)Landroidx/compose/foundation/shape/CornerBasedShape;
-	public static final fun textStyleFromTextAppearance (Landroid/content/Context;Landroidx/compose/ui/unit/Density;IZ)Landroidx/compose/ui/text/TextStyle;
+	public static final fun textStyleFromTextAppearance (Landroid/content/Context;Landroidx/compose/ui/unit/Density;IZLandroidx/compose/ui/text/font/FontFamily;)Landroidx/compose/ui/text/TextStyle;
 }
 
 public final class com/google/android/material/composethemeadapter/TypographyKt {

--- a/lib/src/androidTest/AndroidManifest.xml
+++ b/lib/src/androidTest/AndroidManifest.xml
@@ -30,6 +30,10 @@
             android:theme="@style/Theme.MdcThemeTest" />
 
         <activity
+            android:name=".DefaultFontFamilyMdcActivity"
+            android:theme="@style/Theme.MdcThemeTest.DefaultFontFamily" />
+
+        <activity
             android:name=".NotMdcActivity"
             android:theme="@style/Theme.MdcThemeTest.NotMdc" />
 

--- a/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcActivity.kt
+++ b/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcActivity.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.android.material.composethemeadapter
 
 import androidx.appcompat.app.AppCompatActivity

--- a/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcActivity.kt
+++ b/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcActivity.kt
@@ -1,0 +1,5 @@
+package com.google.android.material.composethemeadapter
+
+import androidx.appcompat.app.AppCompatActivity
+
+class DefaultFontFamilyMdcActivity : AppCompatActivity()

--- a/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcThemeTest.kt
+++ b/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcThemeTest.kt
@@ -116,30 +116,19 @@ private fun Typography.assertFontFamilies(
     expected: FontFamily,
     notEquals: Boolean = false
 ) {
-    h1.fontFamily.assertFontFamily(expected, notEquals)
-    h2.fontFamily.assertFontFamily(expected, notEquals)
-    h3.fontFamily.assertFontFamily(expected, notEquals)
-    h4.fontFamily.assertFontFamily(expected, notEquals)
-    h5.fontFamily.assertFontFamily(expected, notEquals)
-    h6.fontFamily.assertFontFamily(expected, notEquals)
-    subtitle1.fontFamily.assertFontFamily(expected, notEquals)
-    subtitle2.fontFamily.assertFontFamily(expected, notEquals)
-    body1.fontFamily.assertFontFamily(expected, notEquals)
-    body2.fontFamily.assertFontFamily(expected, notEquals)
-    button.fontFamily.assertFontFamily(expected, notEquals)
-    caption.fontFamily.assertFontFamily(expected, notEquals)
-    overline.fontFamily.assertFontFamily(expected, notEquals)
-}
-
-private fun FontFamily?.assertFontFamily(
-    expected: FontFamily,
-    notEquals: Boolean = false
-) {
-    if (notEquals) {
-        assertNotEquals(expected, this)
-    } else {
-        assertEquals(expected, this)
-    }
+    if (notEquals) assertNotEquals(expected, h1.fontFamily) else assertEquals(expected, h1.fontFamily)
+    if (notEquals) assertNotEquals(expected, h2.fontFamily) else assertEquals(expected, h2.fontFamily)
+    if (notEquals) assertNotEquals(expected, h3.fontFamily) else assertEquals(expected, h3.fontFamily)
+    if (notEquals) assertNotEquals(expected, h4.fontFamily) else assertEquals(expected, h4.fontFamily)
+    if (notEquals) assertNotEquals(expected, h5.fontFamily) else assertEquals(expected, h5.fontFamily)
+    if (notEquals) assertNotEquals(expected, h6.fontFamily) else assertEquals(expected, h6.fontFamily)
+    if (notEquals) assertNotEquals(expected, subtitle1.fontFamily) else assertEquals(expected, subtitle1.fontFamily)
+    if (notEquals) assertNotEquals(expected, subtitle2.fontFamily) else assertEquals(expected, subtitle2.fontFamily)
+    if (notEquals) assertNotEquals(expected, body1.fontFamily) else assertEquals(expected, body1.fontFamily)
+    if (notEquals) assertNotEquals(expected, body2.fontFamily) else assertEquals(expected, body2.fontFamily)
+    if (notEquals) assertNotEquals(expected, button.fontFamily) else assertEquals(expected, button.fontFamily)
+    if (notEquals) assertNotEquals(expected, caption.fontFamily) else assertEquals(expected, caption.fontFamily)
+    if (notEquals) assertNotEquals(expected, overline.fontFamily) else assertEquals(expected, overline.fontFamily)
 }
 
 /**

--- a/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcThemeTest.kt
+++ b/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcThemeTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.android.material.composethemeadapter
 
 import android.view.ContextThemeWrapper
@@ -25,105 +41,105 @@ import org.junit.runners.JUnit4
 @MediumTest
 @RunWith(JUnit4::class)
 class DefaultFontFamilyMdcThemeTest {
-  @get:Rule
-  val composeTestRule = createAndroidComposeRule<DefaultFontFamilyMdcActivity>()
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<DefaultFontFamilyMdcActivity>()
 
-  @Test
-  @SdkSuppress(maxSdkVersion = 22) // On API 21-22, the family is loaded with only the 400 font
-  fun rubik_family_api21() = composeTestRule.setContent {
-    val rubik = Font(R.font.rubik, FontWeight.W400).toFontFamily()
-    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik) {
-      MdcTheme(setDefaultFontFamily = true) {
-        MaterialTheme.typography.assertFontFamilies(expected = rubik)
-      }
+    @Test
+    @SdkSuppress(maxSdkVersion = 22) // On API 21-22, the family is loaded with only the 400 font
+    fun rubik_family_api21() = composeTestRule.setContent {
+        val rubik = Font(R.font.rubik, FontWeight.W400).toFontFamily()
+        WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik) {
+            MdcTheme(setDefaultFontFamily = true) {
+                MaterialTheme.typography.assertFontFamilies(expected = rubik)
+            }
+        }
+        WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik) {
+            MdcTheme(setDefaultFontFamily = true) {
+                MaterialTheme.typography.assertFontFamilies(expected = rubik)
+            }
+        }
     }
-    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik) {
-      MdcTheme(setDefaultFontFamily = true) {
-        MaterialTheme.typography.assertFontFamilies(expected = rubik)
-      }
-    }
-  }
 
-  @Test
-  @SdkSuppress(minSdkVersion = 23) // XML font families with >1 fonts are only supported on API 23+
-  fun rubik_family_api23() = composeTestRule.setContent {
-    val rubik = FontFamily(
-      Font(R.font.rubik_300, FontWeight.W300),
-      Font(R.font.rubik_400, FontWeight.W400),
-      Font(R.font.rubik_500, FontWeight.W500),
-      Font(R.font.rubik_700, FontWeight.W700),
-    )
-    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik) {
-      MdcTheme(setDefaultFontFamily = true) {
-        MaterialTheme.typography.assertFontFamilies(expected = rubik)
-      }
-    }
-    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik) {
-      MdcTheme(setDefaultFontFamily = true) {
-        MaterialTheme.typography.assertFontFamilies(expected = rubik)
-      }
-    }
-  }
-
-  @Test
-  fun rubik_fixed400() = composeTestRule.setContent {
-    val rubik400 = Font(R.font.rubik_400, FontWeight.W400).toFontFamily()
-    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik400) {
-      MdcTheme(setDefaultFontFamily = true) {
-        MaterialTheme.typography.assertFontFamilies(expected = rubik400)
-      }
-    }
-    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik400) {
-      MdcTheme(setDefaultFontFamily = true) {
-        MaterialTheme.typography.assertFontFamilies(expected = rubik400)
-      }
-    }
-  }
-
-  @Test
-  fun rubik_fixed700_withTextAppearances() = composeTestRule.setContent {
-    val rubik700 = Font(R.font.rubik_700, FontWeight.W700).toFontFamily()
-    WithThemeOverlay(
-      R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamilies_Rubik700_WithTextAppearances
-    ) {
-      MdcTheme {
-        MaterialTheme.typography.assertFontFamilies(
-          expected = rubik700,
-          notEquals = true
+    @Test
+    @SdkSuppress(minSdkVersion = 23) // XML font families with >1 fonts are only supported on API 23+
+    fun rubik_family_api23() = composeTestRule.setContent {
+        val rubik = FontFamily(
+            Font(R.font.rubik_300, FontWeight.W300),
+            Font(R.font.rubik_400, FontWeight.W400),
+            Font(R.font.rubik_500, FontWeight.W500),
+            Font(R.font.rubik_700, FontWeight.W700),
         )
-      }
+        WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik) {
+            MdcTheme(setDefaultFontFamily = true) {
+                MaterialTheme.typography.assertFontFamilies(expected = rubik)
+            }
+        }
+        WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik) {
+            MdcTheme(setDefaultFontFamily = true) {
+                MaterialTheme.typography.assertFontFamilies(expected = rubik)
+            }
+        }
     }
-  }
+
+    @Test
+    fun rubik_fixed400() = composeTestRule.setContent {
+        val rubik400 = Font(R.font.rubik_400, FontWeight.W400).toFontFamily()
+        WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik400) {
+            MdcTheme(setDefaultFontFamily = true) {
+                MaterialTheme.typography.assertFontFamilies(expected = rubik400)
+            }
+        }
+        WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik400) {
+            MdcTheme(setDefaultFontFamily = true) {
+                MaterialTheme.typography.assertFontFamilies(expected = rubik400)
+            }
+        }
+    }
+
+    @Test
+    fun rubik_fixed700_withTextAppearances() = composeTestRule.setContent {
+        val rubik700 = Font(R.font.rubik_700, FontWeight.W700).toFontFamily()
+        WithThemeOverlay(
+            R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamilies_Rubik700_WithTextAppearances
+        ) {
+            MdcTheme {
+                MaterialTheme.typography.assertFontFamilies(
+                    expected = rubik700,
+                    notEquals = true
+                )
+            }
+        }
+    }
 }
 
 private fun Typography.assertFontFamilies(
-  expected: FontFamily,
-  notEquals: Boolean = false
+    expected: FontFamily,
+    notEquals: Boolean = false
 ) {
-  h1.fontFamily.assertFontFamily(expected, notEquals)
-  h2.fontFamily.assertFontFamily(expected, notEquals)
-  h3.fontFamily.assertFontFamily(expected, notEquals)
-  h4.fontFamily.assertFontFamily(expected, notEquals)
-  h5.fontFamily.assertFontFamily(expected, notEquals)
-  h6.fontFamily.assertFontFamily(expected, notEquals)
-  subtitle1.fontFamily.assertFontFamily(expected, notEquals)
-  subtitle2.fontFamily.assertFontFamily(expected, notEquals)
-  body1.fontFamily.assertFontFamily(expected, notEquals)
-  body2.fontFamily.assertFontFamily(expected, notEquals)
-  button.fontFamily.assertFontFamily(expected, notEquals)
-  caption.fontFamily.assertFontFamily(expected, notEquals)
-  overline.fontFamily.assertFontFamily(expected, notEquals)
+    h1.fontFamily.assertFontFamily(expected, notEquals)
+    h2.fontFamily.assertFontFamily(expected, notEquals)
+    h3.fontFamily.assertFontFamily(expected, notEquals)
+    h4.fontFamily.assertFontFamily(expected, notEquals)
+    h5.fontFamily.assertFontFamily(expected, notEquals)
+    h6.fontFamily.assertFontFamily(expected, notEquals)
+    subtitle1.fontFamily.assertFontFamily(expected, notEquals)
+    subtitle2.fontFamily.assertFontFamily(expected, notEquals)
+    body1.fontFamily.assertFontFamily(expected, notEquals)
+    body2.fontFamily.assertFontFamily(expected, notEquals)
+    button.fontFamily.assertFontFamily(expected, notEquals)
+    caption.fontFamily.assertFontFamily(expected, notEquals)
+    overline.fontFamily.assertFontFamily(expected, notEquals)
 }
 
 private fun FontFamily?.assertFontFamily(
-  expected: FontFamily,
-  notEquals: Boolean = false
+    expected: FontFamily,
+    notEquals: Boolean = false
 ) {
-  if (notEquals) {
-    assertNotEquals(expected, this)
-  } else {
-    assertEquals(expected, this)
-  }
+    if (notEquals) {
+        assertNotEquals(expected, this)
+    } else {
+        assertEquals(expected, this)
+    }
 }
 
 /**
@@ -131,9 +147,9 @@ private fun FontFamily?.assertFontFamily(
  */
 @Composable
 fun WithThemeOverlay(
-  @StyleRes themeOverlayId: Int,
-  content: @Composable () -> Unit,
+    @StyleRes themeOverlayId: Int,
+    content: @Composable () -> Unit,
 ) {
-  val themedContext = ContextThemeWrapper(LocalContext.current, themeOverlayId)
-  CompositionLocalProvider(LocalContext provides themedContext, content = content)
+    val themedContext = ContextThemeWrapper(LocalContext.current, themeOverlayId)
+    CompositionLocalProvider(LocalContext provides themedContext, content = content)
 }

--- a/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcThemeTest.kt
+++ b/lib/src/androidTest/java/com/google/android/material/composethemeadapter/DefaultFontFamilyMdcThemeTest.kt
@@ -1,0 +1,139 @@
+package com.google.android.material.composethemeadapter
+
+import android.view.ContextThemeWrapper
+import androidx.annotation.StyleRes
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.toFontFamily
+import androidx.test.filters.MediumTest
+import androidx.test.filters.SdkSuppress
+import com.google.android.material.composethemeadapter.test.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@MediumTest
+@RunWith(JUnit4::class)
+class DefaultFontFamilyMdcThemeTest {
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<DefaultFontFamilyMdcActivity>()
+
+  @Test
+  @SdkSuppress(maxSdkVersion = 22) // On API 21-22, the family is loaded with only the 400 font
+  fun rubik_family_api21() = composeTestRule.setContent {
+    val rubik = Font(R.font.rubik, FontWeight.W400).toFontFamily()
+    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik) {
+      MdcTheme(setDefaultFontFamily = true) {
+        MaterialTheme.typography.assertFontFamilies(expected = rubik)
+      }
+    }
+    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik) {
+      MdcTheme(setDefaultFontFamily = true) {
+        MaterialTheme.typography.assertFontFamilies(expected = rubik)
+      }
+    }
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = 23) // XML font families with >1 fonts are only supported on API 23+
+  fun rubik_family_api23() = composeTestRule.setContent {
+    val rubik = FontFamily(
+      Font(R.font.rubik_300, FontWeight.W300),
+      Font(R.font.rubik_400, FontWeight.W400),
+      Font(R.font.rubik_500, FontWeight.W500),
+      Font(R.font.rubik_700, FontWeight.W700),
+    )
+    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik) {
+      MdcTheme(setDefaultFontFamily = true) {
+        MaterialTheme.typography.assertFontFamilies(expected = rubik)
+      }
+    }
+    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik) {
+      MdcTheme(setDefaultFontFamily = true) {
+        MaterialTheme.typography.assertFontFamilies(expected = rubik)
+      }
+    }
+  }
+
+  @Test
+  fun rubik_fixed400() = composeTestRule.setContent {
+    val rubik400 = Font(R.font.rubik_400, FontWeight.W400).toFontFamily()
+    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamily_Rubik400) {
+      MdcTheme(setDefaultFontFamily = true) {
+        MaterialTheme.typography.assertFontFamilies(expected = rubik400)
+      }
+    }
+    WithThemeOverlay(R.style.ThemeOverlay_MdcThemeTest_DefaultAndroidFontFamily_Rubik400) {
+      MdcTheme(setDefaultFontFamily = true) {
+        MaterialTheme.typography.assertFontFamilies(expected = rubik400)
+      }
+    }
+  }
+
+  @Test
+  fun rubik_fixed700_withTextAppearances() = composeTestRule.setContent {
+    val rubik700 = Font(R.font.rubik_700, FontWeight.W700).toFontFamily()
+    WithThemeOverlay(
+      R.style.ThemeOverlay_MdcThemeTest_DefaultFontFamilies_Rubik700_WithTextAppearances
+    ) {
+      MdcTheme {
+        MaterialTheme.typography.assertFontFamilies(
+          expected = rubik700,
+          notEquals = true
+        )
+      }
+    }
+  }
+}
+
+private fun Typography.assertFontFamilies(
+  expected: FontFamily,
+  notEquals: Boolean = false
+) {
+  h1.fontFamily.assertFontFamily(expected, notEquals)
+  h2.fontFamily.assertFontFamily(expected, notEquals)
+  h3.fontFamily.assertFontFamily(expected, notEquals)
+  h4.fontFamily.assertFontFamily(expected, notEquals)
+  h5.fontFamily.assertFontFamily(expected, notEquals)
+  h6.fontFamily.assertFontFamily(expected, notEquals)
+  subtitle1.fontFamily.assertFontFamily(expected, notEquals)
+  subtitle2.fontFamily.assertFontFamily(expected, notEquals)
+  body1.fontFamily.assertFontFamily(expected, notEquals)
+  body2.fontFamily.assertFontFamily(expected, notEquals)
+  button.fontFamily.assertFontFamily(expected, notEquals)
+  caption.fontFamily.assertFontFamily(expected, notEquals)
+  overline.fontFamily.assertFontFamily(expected, notEquals)
+}
+
+private fun FontFamily?.assertFontFamily(
+  expected: FontFamily,
+  notEquals: Boolean = false
+) {
+  if (notEquals) {
+    assertNotEquals(expected, this)
+  } else {
+    assertEquals(expected, this)
+  }
+}
+
+/**
+ * Function which applies an Android theme overlay to the current context.
+ */
+@Composable
+fun WithThemeOverlay(
+  @StyleRes themeOverlayId: Int,
+  content: @Composable () -> Unit,
+) {
+  val themedContext = ContextThemeWrapper(LocalContext.current, themeOverlayId)
+  CompositionLocalProvider(LocalContext provides themedContext, content = content)
+}

--- a/lib/src/androidTest/res/values/themes.xml
+++ b/lib/src/androidTest/res/values/themes.xml
@@ -53,6 +53,43 @@
         <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.MdcThemeTest.CutNoSize</item>
     </style>
 
+    <style name="Theme.MdcThemeTest.DefaultFontFamily" parent="Theme.MaterialComponents.DayNight" />
+
+    <style name="ThemeOverlay.MdcThemeTest.DefaultFontFamily.Rubik" parent="">
+        <item name="fontFamily">@font/rubik</item>
+    </style>
+
+    <style name="ThemeOverlay.MdcThemeTest.DefaultAndroidFontFamily.Rubik" parent="">
+        <item name="android:fontFamily">@font/rubik</item>
+    </style>
+
+    <style name="ThemeOverlay.MdcThemeTest.DefaultFontFamily.Rubik400" parent="">
+        <item name="fontFamily">@font/rubik_400</item>
+    </style>
+
+    <style name="ThemeOverlay.MdcThemeTest.DefaultAndroidFontFamily.Rubik400" parent="">
+        <item name="android:fontFamily">@font/rubik_400</item>
+    </style>
+
+    <style name="ThemeOverlay.MdcThemeTest.DefaultFontFamilies.Rubik700.WithTextAppearances" parent="">
+        <item name="fontFamily">@font/rubik_700</item>
+        <item name="android:fontFamily">@font/rubik_700</item>
+        <!-- None of the below TextAppearance styles use (or should use) @font/rubik_700 -->
+        <item name="textAppearanceHeadline1">@style/TextAppearance.MdcThemeTest.Headline1</item>
+        <item name="textAppearanceHeadline2">@style/TextAppearance.MdcThemeTest.Headline2</item>
+        <item name="textAppearanceHeadline3">@style/TextAppearance.MdcThemeTest.Headline3</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.MdcThemeTest.Headline4</item>
+        <item name="textAppearanceHeadline5">@style/TextAppearance.MdcThemeTest.Headline5</item>
+        <item name="textAppearanceHeadline6">@style/TextAppearance.MdcThemeTest.Headline6</item>
+        <item name="textAppearanceSubtitle1">@style/TextAppearance.MdcThemeTest.Subtitle1</item>
+        <item name="textAppearanceSubtitle2">@style/TextAppearance.MdcThemeTest.Subtitle2</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.MdcThemeTest.Body1</item>
+        <item name="textAppearanceBody2">@style/TextAppearance.MdcThemeTest.Body2</item>
+        <item name="textAppearanceCaption">@style/TextAppearance.MdcThemeTest.Caption</item>
+        <item name="textAppearanceButton">@style/TextAppearance.MdcThemeTest.Button</item>
+        <item name="textAppearanceOverline">@style/TextAppearance.MdcThemeTest.Overline</item>
+    </style>
+
     <style name="Theme.MdcThemeTest.NotMdc" parent="Theme.AppCompat.DayNight" />
 
 </resources>

--- a/lib/src/main/java/com/google/android/material/composethemeadapter/MdcTheme.kt
+++ b/lib/src/main/java/com/google/android/material/composethemeadapter/MdcTheme.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.core.content.res.getResourceIdOrThrow
@@ -62,6 +63,8 @@ import java.lang.reflect.Method
  * If `false`, the current value of [MaterialTheme.shapes] is preserved.
  * @param setTextColors whether to read the colors from the `TextAppearance`s associated from the
  * theme. Defaults to `false`.
+ * @param setDefaultFontFamily whether to read and prioritize the `fontFamily` attributes from
+ * [context]'s theme, over any specified in the MDC text appearances. Defaults to `false`.
  */
 @Composable
 fun MdcTheme(
@@ -70,6 +73,7 @@ fun MdcTheme(
     readTypography: Boolean = true,
     readShapes: Boolean = true,
     setTextColors: Boolean = false,
+    setDefaultFontFamily: Boolean = false,
     content: @Composable () -> Unit
 ) {
     // We try and use the theme key value if available, which should be a perfect key for caching
@@ -90,7 +94,8 @@ fun MdcTheme(
             readColors = readColors,
             readTypography = readTypography,
             readShapes = readShapes,
-            setTextColors = setTextColors
+            setTextColors = setTextColors,
+            setDefaultFontFamily = setDefaultFontFamily
         )
     }
 
@@ -143,6 +148,8 @@ data class ThemeParameters(
  * @param readShapes whether the read the MDC shape appearances from the [context]'s theme.
  * @param setTextColors whether to read the colors from the `TextAppearance`s associated from the
  * theme. Defaults to `false`.
+ * @param setDefaultFontFamily whether to read and prioritize the `fontFamily` attributes from
+ * [context]'s theme, over any specified in the MDC text appearances. Defaults to `false`.
  * @return [ThemeParameters] instance containing the resulting [Colors], [Typography]
  * and [Shapes].
  */
@@ -153,7 +160,8 @@ fun createMdcTheme(
     readColors: Boolean = true,
     readTypography: Boolean = true,
     readShapes: Boolean = true,
-    setTextColors: Boolean = false
+    setTextColors: Boolean = false,
+    setDefaultFontFamily: Boolean = false
 ): ThemeParameters {
     return context.obtainStyledAttributes(R.styleable.ComposeThemeAdapterTheme).use { ta ->
         require(ta.hasValue(R.styleable.ComposeThemeAdapterTheme_isMaterialTheme)) {
@@ -219,84 +227,105 @@ fun createMdcTheme(
          */
 
         val typography = if (readTypography) {
-            Typography().merge(
+            val defaultFontFamily = if (setDefaultFontFamily) {
+                val defaultFontFamilyWithWeight: FontFamilyWithWeight? = ta.getFontFamilyOrNull(
+                    R.styleable.ComposeThemeAdapterTheme_fontFamily
+                ) ?: ta.getFontFamilyOrNull(R.styleable.ComposeThemeAdapterTheme_android_fontFamily)
+                defaultFontFamilyWithWeight?.fontFamily
+            } else {
+                null
+            }
+            Typography(defaultFontFamily = defaultFontFamily ?: FontFamily.Default).merge(
                 h1 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceHeadline1),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 h2 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceHeadline2),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 h3 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceHeadline3),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 h4 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceHeadline4),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 h5 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceHeadline5),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 h6 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceHeadline6),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 subtitle1 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceSubtitle1),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 subtitle2 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceSubtitle2),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 body1 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceBody1),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 body2 = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceBody2),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 button = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceButton),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 caption = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceCaption),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 ),
                 overline = textStyleFromTextAppearance(
                     context,
                     density,
                     ta.getResourceIdOrThrow(R.styleable.ComposeThemeAdapterTheme_textAppearanceOverline),
-                    setTextColors
+                    setTextColors,
+                    defaultFontFamily
                 )
             )
         } else null

--- a/lib/src/main/java/com/google/android/material/composethemeadapter/TypedArrayUtils.kt
+++ b/lib/src/main/java/com/google/android/material/composethemeadapter/TypedArrayUtils.kt
@@ -53,7 +53,8 @@ internal fun textStyleFromTextAppearance(
     context: Context,
     density: Density,
     @StyleRes id: Int,
-    setTextColors: Boolean
+    setTextColors: Boolean,
+    defaultFontFamily: FontFamily?
 ): TextStyle {
     return context.obtainStyledAttributes(id, R.styleable.ComposeThemeAdapterTextAppearance).use { a ->
         val textStyle = a.getInt(R.styleable.ComposeThemeAdapterTextAppearance_android_textStyle, -1)
@@ -82,6 +83,7 @@ internal fun textStyleFromTextAppearance(
                     ?: TextUnit.Unspecified
             },
             fontFamily = when {
+                defaultFontFamily != null -> defaultFontFamily
                 fontFamily != null -> fontFamily.fontFamily
                 // Values below are from frameworks/base attrs.xml
                 typeface == 1 -> FontFamily.SansSerif

--- a/lib/src/main/res/values/theme_attrs.xml
+++ b/lib/src/main/res/values/theme_attrs.xml
@@ -33,6 +33,8 @@
         <attr name="colorError" />
         <attr name="colorOnError" />
 
+        <attr name="fontFamily" />
+        <attr name="android:fontFamily" />
         <attr name="textAppearanceBody1" />
         <attr name="textAppearanceBody2" />
         <attr name="textAppearanceButton" />


### PR DESCRIPTION
This adds optional functionality to read and prioritize the `fontFamily`/`android:FontFamily` attribute from the theme, over any specified in the MDC text appearances.

This was adapted from the AppCompat Compose Theme Adapter library.

resolves #73 