### PR TITLE
Adapt lineSpacingMultiplier attribute

### DIFF
--- a/material3Lib/src/main/java/com/google/android/material/composethemeadapter3/TypedArrayUtils.kt
+++ b/material3Lib/src/main/java/com/google/android/material/composethemeadapter3/TypedArrayUtils.kt
@@ -63,6 +63,7 @@ internal fun textStyleFromTextAppearance(
             R.styleable.ComposeThemeAdapterTextAppearance_fontFamily
         ) ?: a.getFontFamilyOrNull(R.styleable.ComposeThemeAdapterTextAppearance_android_fontFamily)
 
+        val fontSize = a.getTextUnit(R.styleable.ComposeThemeAdapterTextAppearance_android_textSize, density)
         TextStyle(
             color = when {
                 setTextColors -> {
@@ -70,10 +71,18 @@ internal fun textStyleFromTextAppearance(
                 }
                 else -> Color.Unspecified
             },
-            fontSize = a.getTextUnit(R.styleable.ComposeThemeAdapterTextAppearance_android_textSize, density),
+            fontSize = fontSize,
             lineHeight = run {
                 a.getTextUnitOrNull(R.styleable.ComposeThemeAdapterTextAppearance_lineHeight, density)
                     ?: a.getTextUnitOrNull(R.styleable.ComposeThemeAdapterTextAppearance_android_lineHeight, density)
+                    ?: a.getFloat(R.styleable.ComposeThemeAdapterTextAppearance_android_lineSpacingMultiplier, -1f)
+                        .let { lineSpacingMultiplier ->
+                            if (lineSpacingMultiplier != -1f) {
+                                (fontSize * lineSpacingMultiplier).takeIf { lineSpacingMultiplier != -1f }
+                            } else {
+                                null
+                            }
+                        }
                     ?: TextUnit.Unspecified
             },
             fontFamily = when {

--- a/material3Lib/src/main/res/values/theme_attrs.xml
+++ b/material3Lib/src/main/res/values/theme_attrs.xml
@@ -83,6 +83,7 @@
 
         <attr name="lineHeight" />
         <attr name="android:lineHeight" />
+        <attr name="android:lineSpacingMultiplier"/>
 
         <attr name="android:letterSpacing" />
 

--- a/materialLib/src/main/java/com/google/android/material/composethemeadapter/TypedArrayUtils.kt
+++ b/materialLib/src/main/java/com/google/android/material/composethemeadapter/TypedArrayUtils.kt
@@ -69,6 +69,7 @@ internal fun textStyleFromTextAppearance(
             R.styleable.ComposeThemeAdapterTextAppearance_fontFamily
         ) ?: a.getFontFamilyOrNull(R.styleable.ComposeThemeAdapterTextAppearance_android_fontFamily)
 
+        val fontSize = a.getTextUnit(R.styleable.ComposeThemeAdapterTextAppearance_android_textSize, density)
         TextStyle(
             color = when {
                 setTextColors -> {
@@ -76,10 +77,18 @@ internal fun textStyleFromTextAppearance(
                 }
                 else -> Color.Unspecified
             },
-            fontSize = a.getTextUnit(R.styleable.ComposeThemeAdapterTextAppearance_android_textSize, density),
+            fontSize = fontSize,
             lineHeight = run {
                 a.getTextUnitOrNull(R.styleable.ComposeThemeAdapterTextAppearance_lineHeight, density)
                     ?: a.getTextUnitOrNull(R.styleable.ComposeThemeAdapterTextAppearance_android_lineHeight, density)
+                    ?: a.getFloat(R.styleable.ComposeThemeAdapterTextAppearance_android_lineSpacingMultiplier, -1f)
+                        .let { lineSpacingMultiplier ->
+                            if (lineSpacingMultiplier != -1f) {
+                                (fontSize * lineSpacingMultiplier).takeIf { lineSpacingMultiplier != -1f }
+                            } else {
+                                null
+                            }
+                        }
                     ?: TextUnit.Unspecified
             },
             fontFamily = when {

--- a/materialLib/src/main/res/values/theme_attrs.xml
+++ b/materialLib/src/main/res/values/theme_attrs.xml
@@ -71,6 +71,7 @@
 
         <attr name="lineHeight" />
         <attr name="android:lineHeight" />
+        <attr name="android:lineSpacingMultiplier"/>
 
         <attr name="android:letterSpacing" />
 


### PR DESCRIPTION
`android:lineSpacingMultiplier` attribute was not read by the theme adapter. This PR read the attributes and apply it if `lineHeight` or `android:lineHeight` is not defined



## Changes
- Adapt lineSpacingMultiplier attribute
- Adapt lineSpacingMultiplier attribute (M3)
